### PR TITLE
Changed version to Java 8, as Java 11 doesn't seem to be required.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
I have some projects I'm targeting Java 8 with, and I'd like to use this lib.  Seems to build ok with Java 8 so seems like a win-win to lower the compiler version.